### PR TITLE
Update development setup documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ To do this we'll use [wasmd](https://github.com/CosmWasm/wasmd) running in a doc
 
 ### Setup Chain
 
-Make sure you install the `docker` locally. In a new terminal, clone the [cw-dao](https://github.com/DA0-DA0/cw-dao) repo, and folow the instructions on running the chain in a development environment.
+In a new terminal, clone the [cw-dao](https://github.com/DA0-DA0/cw-dao) repo, and folow the instructions in that repo on running the chain in a development environment.
 
 ### Setup Frontend
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ To do this we'll use [wasmd](https://github.com/CosmWasm/wasmd) running in a doc
 
 ### Setup Chain
 
-In a new terminal, clone the [cw-dao](https://github.com/DA0-DA0/cw-dao) repo, and folow the instructions in that repo on running the chain in a development environment.
+In a new terminal, clone the [cw-dao](https://github.com/DA0-DA0/cw-dao) repo, and folow [the instructions for running the chain in a development environment](https://github.com/DA0-DA0/cw-dao#deploying-in-a-development-environment).
+
+Assuming you follow those directions to configure it with the default wasm account, you'll also want to import that account's mnemonic into Keplr (Add account -> Import existing account -> copy mnemonic from [default account](https://github.com/DA0-DA0/cw-dao/blob/main/default-account.txt)).
 
 ### Setup Frontend
 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,9 @@ To do this we'll use [wasmd](https://github.com/CosmWasm/wasmd) running in a doc
 
 ### Setup Chain
 
-In a new terminal, clone the [cw-dao](https://github.com/DA0-DA0/cw-dao) repo, and folow [the instructions for running the chain in a development environment](https://github.com/DA0-DA0/cw-dao#deploying-in-a-development-environment).
+First, make sure you have `docker` installed. 
+
+Then, in a new terminal, clone the [cw-dao](https://github.com/DA0-DA0/cw-dao) repo, and folow [the instructions for running the chain in a development environment](https://github.com/DA0-DA0/cw-dao#deploying-in-a-development-environment).
 
 > Note: Assuming you follow those directions to configure it with the default wasm account, you'll also want to import that account's mnemonic into Keplr (Add account -> Import existing account -> copy mnemonic from [default account](https://github.com/DA0-DA0/cw-dao/blob/main/default-account.txt)).
 

--- a/README.md
+++ b/README.md
@@ -26,15 +26,7 @@ To do this we'll use [wasmd](https://github.com/CosmWasm/wasmd) running in a doc
 
 ### Setup Chain
 
-Make sure you install the `docker` locally. In a new terminal, clone the [cw-dao](https://github.com/DA0-DA0/cw-dao) repo, and run the deploy contracts script.
-
-```bash
-git clone https://github.com/DA0-DA0/cw-dao
-cd cw-dao
-bash scripts/deploy_local.sh
-```
-
-Make note of the addresses and private key from the output; these are the contracts deployed on a chain running in a docker container on your machine as well as the private key to an account with a balance you can import into [Kelpr](https://www.keplr.app/).
+Make sure you install the `docker` locally. In a new terminal, clone the [cw-dao](https://github.com/DA0-DA0/cw-dao) repo, and folow the instructions on running the chain in a development environment.
 
 ### Setup Frontend
 
@@ -72,6 +64,8 @@ yarn dev
 Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 You can start editing the page by modifying `pages/index.tsx`. The page auto-updates as you edit the file.
+
+Note: If you change  `.env.local`, you'll need to re-add the chain to Keplr. If you select a different chain in Keplr (like Cosmos), you can scroll down and remove the "Wasmd Test" chain, then you can re-add it by connecting your wallet.
 
 ## Requirements
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ To do this we'll use [wasmd](https://github.com/CosmWasm/wasmd) running in a doc
 
 In a new terminal, clone the [cw-dao](https://github.com/DA0-DA0/cw-dao) repo, and folow [the instructions for running the chain in a development environment](https://github.com/DA0-DA0/cw-dao#deploying-in-a-development-environment).
 
-Assuming you follow those directions to configure it with the default wasm account, you'll also want to import that account's mnemonic into Keplr (Add account -> Import existing account -> copy mnemonic from [default account](https://github.com/DA0-DA0/cw-dao/blob/main/default-account.txt)).
+> Note: Assuming you follow those directions to configure it with the default wasm account, you'll also want to import that account's mnemonic into Keplr (Add account -> Import existing account -> copy mnemonic from [default account](https://github.com/DA0-DA0/cw-dao/blob/main/default-account.txt)).
 
 ### Setup Frontend
 


### PR DESCRIPTION
This PR documents an `.env.local` gotcha. It also removes instructions on chain setup, directing developers to look at the cw-dao repo instead. This latter change prevents us from having to sync instructions as development flows change, possibly leaving developers with stale instructions in the process.